### PR TITLE
chore: drop Flutter 3.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event_name == 'pull_request'
     strategy:
       matrix:
-        flutter-version: ["3.19", "3.22", "3.24", "3.27", "3.29"]
+        flutter-version: ["3.22", "3.24", "3.27", "3.29"]
     uses: BlindfoldedSurgery/actions-container/.github/workflows/build-dual-image-kaniko.yml@v7
     with:
       additional-build-args: |
@@ -45,7 +45,7 @@ jobs:
     needs: bump
     strategy:
       matrix:
-        flutter-version: ["3.19", "3.22", "3.24", "3.27", "3.29"]
+        flutter-version: ["3.22", "3.24", "3.27", "3.29"]
     uses: BlindfoldedSurgery/actions-container/.github/workflows/build-dual-image-kaniko.yml@v7
     with:
       additional-build-args: |


### PR DESCRIPTION
BREAKING CHANGE: support for Flutter 3.19 (released on 2024-02-15) was dropped from this release